### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The project is in early development stage but the core functionality is already 
 
 Features
 ========
-- Theme.GreenMatter theme availabe for Android ICS and newer
+- Theme.GreenMatter theme available for Android ICS and newer
 - Define colors in theme: colorPrimary, colorAccent, colorControlActivated...
 - Programmatically override the colors at runtime
 - Colored buttons by simply specifying the button color


### PR DESCRIPTION
negusoft, I've corrected a typographical error in the documentation of the [GreenMatter](https://github.com/negusoft/GreenMatter) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
